### PR TITLE
Stop using the SimpleSAML_Session::setAttribute() method that has bee…

### DIFF
--- a/www/changePassword.php
+++ b/www/changePassword.php
@@ -11,6 +11,11 @@ $asId = $uregconf->getString('auth');
 $as = new SimpleSAML_Auth_Simple($asId);
 $as->requireAuth();
 $attributes = $as->getAttributes();
+$session = SimpleSAML_Session::getSessionFromRequest();
+$data = $session->getData('selfregister:updated', 'attributes');
+if ($data !== NULL) {
+	$attributes = $data;
+}
 
 $formGen = new sspmod_selfregister_XHTML_Form($formFields, 'changePassword.php');
 $fields = array('pw1', 'pw2');

--- a/www/delUser.php
+++ b/www/delUser.php
@@ -13,6 +13,11 @@ $as->requireAuth();
 
 /* Retrieve attributes of the user. */
 $attributes = $as->getAttributes();
+$session = SimpleSAML_Session::getSessionFromRequest();
+$data = $session->getData('selfregister:updated', 'attributes');
+if ($data !== NULL) {
+	$attributes = $data;
+}
 
 $formFields = $uregconf->getArray('formFields');
 $reviewAttr = $uregconf->getArray('attributes');

--- a/www/reviewUser.php
+++ b/www/reviewUser.php
@@ -13,6 +13,12 @@ $as->requireAuth();
 /* Retrieve attributes of the user. */
 $attributes = $as->getAttributes();
 
+$session = SimpleSAML_Session::getSessionFromRequest();
+$data = $session->getData('selfregister:updated', 'attributes');
+if ($data !== NULL) {
+	$attributes = $data;
+}
+
 $formFields = $uregconf->getArray('formFields');
 $reviewAttr = $uregconf->getArray('attributes');
 
@@ -68,14 +74,11 @@ if(array_key_exists('sender', $_POST)) {
 		// But now atributes from the logged user is obsolete, So I can actualize it and get values from session
 		// but maybe we could have security problem if IdP isnt configured correctly.
 
-		$session = SimpleSAML_Session::getInstance();
-
 		foreach($userInfo as $name => $value) {
 			$attributes[$name][0] = $value;
-			$session->setAttribute($name, $attributes[$name]);
 		}
+		$session->setData('selfregister:updated', 'attributes', $attributes, SimpleSAML_Session::DATA_TIMEOUT_SESSION_END);
 
-		$attributes = $as->getAttributes();
 		$values = sspmod_selfregister_Util::filterAsAttributes($attributes, $reviewAttr);
 
 		$html->data['userMessage'] = 'message_chuinfo';


### PR DESCRIPTION
…n deleted. Store updated attributes into the data storage of the session instead.